### PR TITLE
Allow non managed files

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,4 +12,4 @@
   service:
     name: prometheus
     state: reloaded
-  when: "{{ prometheus_service_reload }}" 
+  when: prometheus_service_reload

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -10,6 +10,7 @@
     path: "{{ prometheus_rules_dir }}/{{ item }}"
     state: absent
   with_items: "{{ rules_content.stdout_lines | difference(prometheus_rules_files) }}"
+  when: "rules_content.stdout_lines is defined"
   notify:
     - reload prometheus
 
@@ -35,6 +36,7 @@
     mode: 0755
   notify:
     - reload prometheus
+  when: "prometheus_non_ansible_managed is defined"
 
 - name: copy prometheus 1st part config
   template:
@@ -61,7 +63,7 @@
     path: "{{ prometheus_config_dir }}/conf.d/{{ item }}"
     state: absent
   with_items: "{{ config_parts_content.stdout_lines | difference(config_parts_local_content.stdout_lines) }}"
-  when: "item != '1-prometheus.yml'"
+  when: "config_parts_content.stdout_lines is defined and item != '1-prometheus.yml'"
 
 - name: copy another config parts
   template:
@@ -103,6 +105,7 @@
     path: "{{ prometheus_file_sd_config_dir }}/{{ item }}"
     state: absent
   with_items: "{{ tgroups_content.stdout_lines | difference(tgroups_local_content.stdout_lines) }}"
+  when: "tgroups_content.stdout_lines is defined"
 
 - name: copy target group files from playbook directory
   copy:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -26,6 +26,16 @@
   notify:
     - reload prometheus
 
+- name: create directory for non-ansible managed rules
+  file:
+    path: "{{ prometheus_non_ansible_managed }}/rules"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: 0755
+  notify:
+    - reload prometheus
+
 - name: copy prometheus 1st part config
   template:
     src: "etc/prometheus/prometheus.yml.j2"

--- a/templates/etc/prometheus/prometheus.yml.j2
+++ b/templates/etc/prometheus/prometheus.yml.j2
@@ -10,6 +10,7 @@ rule_files:
   - {{ prometheus_rules_dir }}/{{ dest }}
   {% endfor %}
 {% endif %}
+  - /etc/prometheus/non-ansible-managed/rules/*.rules
 
 # A list of scrape configurations.
 scrape_configs:


### PR DESCRIPTION
This allows dropping .rules files in /etc/prometheus/non-ansible-managed/rules/ that will not be managed by Ansible, but will still be included in the Prometheus config.